### PR TITLE
MessagesApi - Fix failing tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "artikcloud/artikcloud-php",
     "version": "2.0.5",
-    "description": "",
+    "description": "This SDK helps you connect your PHP scripts to ARTIK Cloud. The SDK exposes a number of methods to easily execute REST API calls to ARTIK Cloud",
     "keywords": [
         "php",
         "sdk",

--- a/test/Api/MessagesApiTest.php
+++ b/test/Api/MessagesApiTest.php
@@ -191,7 +191,7 @@ class MessagesApiTest extends ArtikTestCase
         $stepsInfo = $data[0]->getData()['steps'];
         $this->assertEquals($sdids, $snapshots->getSdids(), 'Sdids must match');
         $this->assertEquals($sdids, $data[0]->getSdid(), 'SDID must match');
-        $this->assertEquals($stepsInfo['value'], 5, 'Steps must be 5');
+        $this->assertEquals($stepsInfo['value'], 500, 'Steps must be 500');
 
     }
 

--- a/test/Api/MessagesApiTest.php
+++ b/test/Api/MessagesApiTest.php
@@ -191,7 +191,7 @@ class MessagesApiTest extends ArtikTestCase
         $stepsInfo = $data[0]->getData()['steps'];
         $this->assertEquals($sdids, $snapshots->getSdids(), 'Sdids must match');
         $this->assertEquals($sdids, $data[0]->getSdid(), 'SDID must match');
-        $this->assertEquals($stepsInfo['value'], 500, 'Steps must be 500');
+        $this->assertEquals($stepsInfo['value'], 5, 'Steps must be 5');
 
     }
 

--- a/test/Api/UsersApiTest.php
+++ b/test/Api/UsersApiTest.php
@@ -101,6 +101,21 @@ class UsersApiTest extends ArtikTestCase
     }
 
     /**
+     * Generates a pseudo-random string of the specified length
+     */
+    public static function randomString($length = 4)
+    {
+
+        $newString = '';
+
+        for ($i = 0; $i <= $length; $i++) {
+            $newString .= chr(rand(97, 122));
+        }
+
+        return $newString;
+    }
+
+    /**
      * Test case for GetUserDeviceTypes
      *
      * Create User Application Properties.
@@ -156,6 +171,9 @@ class UsersApiTest extends ArtikTestCase
         $userId = static::$artikParams['user1']['id'];
         $aid = static::$artikParams['user1']['aid'];
 
+        // Generate temporary property
+        $property = static::randomString();
+
         try {
             // Read
             $userProperties = self::$users_api->GetUserProperties($userId, $aid);
@@ -167,7 +185,7 @@ class UsersApiTest extends ArtikTestCase
 
                 // Create
                 $appProperties = new AppProperties();
-                $appProperties->setProperties('abc=def');
+                $appProperties->setProperties($property);
 
                 $userProperties = self::$users_api->CreateUserProperties($userId, $appProperties, $aid);
             } else {
@@ -180,10 +198,10 @@ class UsersApiTest extends ArtikTestCase
 
         // Update
         $appProperties2 = new AppProperties();
-        $appProperties2->setProperties('mno=pqr');
+        $appProperties2->setProperties($property);
         $userProperties2 = self::$users_api->UpdateUserProperties($userId, $appProperties2, $aid);
         $this->assertNotNull($userProperties2);
-        $this->assertEquals('mno=pqr', $appProperties2->getProperties(), 'Properties must be the same');
+        $this->assertEquals($property, $appProperties2->getProperties(), 'Properties must be the same ($property)');
 
         // Delete
         $userProperties3 = self::$users_api->DeleteUserProperties($userId, $aid);


### PR DESCRIPTION
Tests were failing because of concurrent builds.

**GetUserProperties CRUD test case** was testing with a hard coded property name, test case is successful when running tests in local but it fails on Travis CI as there are 4 concurrent builds, all of them using the same database so builds colide when a build deletes such property and the others try to read/update/delete it.

So the test case was improved to use a pseudo-random string for each build.
